### PR TITLE
Fix CloudFormation template

### DIFF
--- a/activity7.yaml
+++ b/activity7.yaml
@@ -108,13 +108,9 @@ Resources:
       Port: 8080
       Protocol: HTTP
       TargetType: instance
-
-  JenkinsTGAttachment:
-    Type: AWS::ElasticLoadBalancingV2::TargetGroupAttachment
-    Properties:
-      TargetGroupArn: !Ref JenkinsTargetGroup
-      TargetId: !Ref JenkinsInstance
-      Port: 8080
+      Targets:
+        - Id: !Ref JenkinsInstance
+          Port: 8080
 
   JenkinsLoadBalancer:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer


### PR DESCRIPTION
## Summary
- register Jenkins instance with target group using `Targets` property
- remove unsupported `TargetGroupAttachment` resource

## Testing
- `python3 -m py_compile activity7.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68471650712c832796801ddaff8ef726